### PR TITLE
feat(inclusion): send recommendations to users when some non-inclusive words are found

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bcneng/candebot/inclusion"
 	"github.com/shomali11/slacker"
 	"github.com/slack-go/slack"
 )
@@ -128,6 +129,9 @@ func eventHandler(adminClient *slack.Client) slacker.EventHandler {
 			case channelCandebotTesting:
 				// Playground here
 			}
+
+			// behaviors that apply to all channels
+			go checkLanguage(s, event)
 		}
 		return slacker.DefaultEventHandler(ctx, s, msg)
 	}
@@ -346,4 +350,10 @@ func isStaff(userID string) bool {
 	_, ok := staffMap[userID]
 
 	return ok
+}
+
+func checkLanguage(bot *slacker.Slacker, event *slack.MessageEvent) {
+	if reply := inclusion.Filter(event.Text); reply != "" {
+		_ = sendEphemeral(bot.Client(), event.Channel, event.User, reply)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/shomali11/proper v0.0.0-20190608032528-6e70a05688e7 // indirect
 	github.com/shomali11/slacker v0.0.0-20200610181250-3156f073f291
 	github.com/slack-go/slack v0.6.5
+	github.com/stretchr/testify v1.3.0
+	golang.org/x/text v0.3.3
 )
 
 replace github.com/shomali11/slacker => github.com/smoya/slacker v0.0.0-20200728103316-563cbd9d3c10

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0U
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/nlopes/slack v0.6.0 h1:jt0jxVQGhssx1Ib7naAOZEZcGdtIhTzkP0nopK0AsRA=
 github.com/nlopes/slack v0.6.0/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -35,3 +36,6 @@ github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/inclusion/language_test.go
+++ b/inclusion/language_test.go
@@ -1,0 +1,40 @@
+package inclusion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		filtered bool
+	}{
+		{name: "LGTB should be LGTB+", input: "I do really support LGTB groups", filtered: true},
+		{name: "LGTB+ should be ok", input: "I do really support LGTB+ groups", filtered: false},
+		{name: "minusvalida debería ser persona discapacitada", input: "Mi vecina es minusvalida", filtered: true},
+		{name: "persona con discapacidad es correcto", input: "Mi vecino es una persona con discapacitad", filtered: false},
+		{name: "bcneng sucks is rude", input: "bcneng sucks", filtered: true},
+		{name: "bcneng is awesome is nice", input: "bcneng is awesome", filtered: false},
+	}
+
+	extraFilters := []InclusiveFilter{
+		{
+			Filter: "bcneng sucks",
+			Reply:  "We do not expect you to love us unconditionally, however we do really love you all!",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := Filter(test.input, extraFilters...)
+			if test.filtered {
+				require.NotEmpty(t, output, output)
+			} else {
+				require.Empty(t, output, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Whenever some words are found in a message, Candebot will reply silently (only visible to the sender) a recommendation for a better inclusive language usage.


The list is based in some articles I've found on the internet, but others are purely on my own, a **privileged white European male**. That means that as starting base it will help, but we should definitely share the list with our community and ask for help. Pr's are totally welcome and we should encourage them.

Example:
![image](https://user-images.githubusercontent.com/1083296/90328523-4349f000-df9d-11ea-84a8-653ad6136d43.png)
