### PR TITLE
feat: #hiring-job-board channel is now using a Workflow for posting offers

### DIFF
--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -1,0 +1,66 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsValidJobOffer(t *testing.T) {
+	tests := []struct {
+		name  string
+		text  string
+		valid bool
+	}{
+		{
+			name:  "Offer following the format is valid",
+			text:  ":computer: Full Stack Engineer @ BcnEng - :moneybag: 70 - 90k  - :round_pushpin: Barcelona - :link: www.bcneng.com/netiquette - :raised_hands: More info DM @smoya",
+			valid: true,
+		},
+		{
+			name:  "Offer without min range is valid",
+			text:  ":computer: Full Stack Engineer @ BcnEng - :moneybag:  - 90k  - :round_pushpin: Barcelona - :link: https://www.bcneng.com/netiquette - :raised_hands: More info DM @smoya",
+			valid: true,
+		},
+		{
+			name:  "Offer with a too long min range is invalid",
+			text:  ":computer: Full Stack Engineer @ BcnEng - :moneybag: 70 but depending on blabla - 90k  - :round_pushpin: Barcelona - :link: https://www.bcneng.com/netiquette - :raised_hands: More info DM @smoya",
+			valid: false,
+		},
+		{
+			name:  "Offer with a too long max range is invalid",
+			text:  ":computer: Full Stack Engineer @ BcnEng - :moneybag: 70 - 90k but depending on blabla  - :round_pushpin: Barcelona - :link: https://www.bcneng.com/netiquette - :raised_hands: More info DM @smoya",
+			valid: false,
+		},
+		{
+			name:  "Offer without max range is invalid",
+			text:  ":computer: Full Stack Engineer @ BcnEng - :moneybag:  -  - :round_pushpin: Barcelona - :link: https://www.bcneng.com/netiquette - :raised_hands: More info DM @smoya",
+			valid: false,
+		},
+		{
+			name:  "Offer with an invalid link",
+			text:  ":computer: Full Stack Engineer @ BcnEng - :moneybag: 70 - 90k  - :round_pushpin: Barcelona - :link: wrong-link - :raised_hands: More info DM @smoya",
+			valid: false,
+		},
+		{
+			name:  "Offer with a missing link is invalid",
+			text:  ":computer: Full Stack Engineer @ BcnEng - :moneybag: 70 - 90k  - :round_pushpin: Barcelona - :link:  - :raised_hands: More info DM @smoya",
+			valid: false,
+		},
+		{
+			name:  "Offer with missing role is invalid",
+			text:  ":computer:  @ BcnEng - :moneybag: 70 - 90k  - :round_pushpin: Barcelona - :link: www.bcneng.com/netiquette - :raised_hands: More info DM @smoya",
+			valid: false,
+		},
+		{
+			name:  "Offer with missing company is invalid",
+			text:  ":computer: Full Stack Engineer @  - :moneybag: 70 - 90k  - :round_pushpin: Barcelona - :link: www.bcneng.com/netiquette - :raised_hands: More info DM @smoya",
+			valid: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.valid, isValidJobOffer(test.text), test.text)
+		})
+	}
+}


### PR DESCRIPTION
We recently set up a new Slack Workflow for posting job offers in #hiring-job-board channel.

Offers published through that workflow look like the following:
![image](https://user-images.githubusercontent.com/1083296/98512463-a4185a00-2266-11eb-8362-8e6380655068.png)

This PR does the following:

- Adapts the regex to the new format. This regex check ensures that the message contains all the required fields. Even though posted with a workflow, people can still introduce wrong values.
- Deletes any post that is not made by a member of the Staff or the Workflow. Also posts a message only visible by the sender that looks like: 
![image](https://user-images.githubusercontent.com/1083296/98512944-67009780-2267-11eb-9b7c-037b9b0e02f5.png)
