### PR TITLE
fix: ignore parsing own bot messages when replying to DM's

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -23,7 +23,10 @@ const (
 	channelCandebotTesting                       = "CK32YCX5M"
 )
 
-const candebotUser = "UJNQU8N5Q"
+const (
+	candebotUser  = "UJNQU8N5Q"
+	candebotBotID = "BJNQBKGJF"
+)
 
 var staff = []string{
 	"U2Y6QQHST", //<@gonzaloserrano>

--- a/bot/events.go
+++ b/bot/events.go
@@ -42,6 +42,11 @@ func eventsAPIHandler(botContext cmd.BotContext) http.HandlerFunc {
 			innerEvent := eventsAPIEvent.InnerEvent
 			switch event := innerEvent.Data.(type) {
 			case *slackevents.MessageEvent:
+				if event.BotID == candebotBotID {
+					// Skip own (bot) command replies
+					return
+				}
+
 				if event.SubType == "" || event.SubType == "message_replied" {
 					// behaviors that apply to all messages posted by users both in channels or threads
 					go checkLanguage(botContext.Client, event)


### PR DESCRIPTION
Candebot is reading it's own DM replies and trying to parse them matching a command, having unexpected and unpredictable behavior:

```
Direct message: :birthday: 278 days until <@U36H6F3CN> birthday! :birthday:
Error parsing kong command:  unexpected argument :birthday:
```

This PR skips those messages.