### PR TITLE
feat: improve inclusive filter for ladies and gentlemen

### DIFF
--- a/inclusion/language.go
+++ b/inclusion/language.go
@@ -48,8 +48,8 @@ var inclusiveFilters = []InclusiveFilter{
 	{Filter: "retraso mental", Reply: "*Retrasado* y *Retraso mental* son términos despectivos eliminados del vocabulario psiquiátrico y, según la OMS, la forma correcta para referiste a ese grupo de enfermedades y transtornos es *Trastorno del desarrollo intelectual* "},
 	
 	// Our own list
-	{Filter: "gentlemen", Reply: "Instead of *gentlemen*, perhaps you mean *folks*?... *[Please consider editing your message so it's more inclusive]*"},
-	{Filter: "ladies", Reply: "Instead of *ladies*, perhaps you mean *folks*?... *[Please consider editing your message so it's more inclusive]*"},
+	{Filter: "gentlem(a|e)n", Reply: "Instead of *gentlem(a|e)n*, perhaps you mean *folks*?... *[Please consider editing your message so it's more inclusive]*"},
+	{Filter: "lad(y|ies)", Reply: "Instead of *lad(y|ies)*, perhaps you mean *folks*?... *[Please consider editing your message so it's more inclusive]*"},
 	{Filter: "los chicos de", Reply: "En vez de *los chicos de*, quizá quisiste decir *el equipo de*, *los integrantes de*?... *[Considera editar tu mensaje para que sea más inclusivo]*"},
 	{Filter: "chicos", Reply: "En vez de *chicos*, quizá quisiste decir *chiques*, *colegas*, *grupo*, *personas*?... *[Considera editar tu mensaje para que sea más inclusivo]*"},
 	{Filter: "lgtb", Reply: "Desde hace un tiempo, el colectivo *LGTB+* recomienda añadir el carácter `+` a la palabra *LGTB*, pues existen orientaciones e identidades que, a pesar de no ser tan predominantes, representan a muchas personas. *[Considera editar tu mensaje para que sea más inclusivo]*"},

--- a/inclusion/language_test.go
+++ b/inclusion/language_test.go
@@ -20,6 +20,7 @@ func TestFilter(t *testing.T) {
 		{name: "bcneng sucks is rude", input: "bcneng sucks", filtered: true},
 		{name: "bcneng is awesome is nice", input: "bcneng is awesome", filtered: false},
 		{name: "'buena localización' is right even though contains the word 'loca'", input: "buena localización", filtered: false},
+		{name: "'ladies' is not usually used in the right context", input: "hi ladies!", filtered: true},
 	}
 
 	extraFilters := []InclusiveFilter{


### PR DESCRIPTION
This PR improves the inclusive filter for the word Gentlemen and Ladies so we can support both singular and plural terms.
It also adds a simple test.

Btw, This PR change has been created using only my Ipad with Github Codespaces.