### PR TITLE
feat: add location for temporary (due to COVID) remote jobs

### DIFF
--- a/bot/interact.go
+++ b/bot/interact.go
@@ -135,6 +135,10 @@ func generateSubmitJobFormDialog() slack.Dialog {
 			Value: "Barcelona/Remote",
 		},
 		{
+			Label: "Remote (temporary because of COVID)",
+			Value: "Remote (COVID)",
+		},
+		{
 			Label: "Remote",
 			Value: "Remote",
 		},


### PR DESCRIPTION
This PR adds a new job location to the form used for submitting jobs that apply for temporary - due to COVID - jobs.