### PR TITLE
feat: send IM when inviting users to join the workspace

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -17,9 +17,9 @@ const (
 )
 
 const (
-	channelHiringJobBoard                        = "C30CUFT2B"
-	channelHiringJobBoardWrongFormatNotification = "G983W7L9F"
-	channelCandebotTesting                       = "CK32YCX5M"
+	channelHiringJobBoard  = "C30CUFT2B"
+	channelStaff           = "G983W7L9F"
+	channelCandebotTesting = "CK32YCX5M"
 )
 
 const (


### PR DESCRIPTION
Invites can not be disabled in Slack, and as they are restricted by now due to legal stuff (we need users to explicitly accept our COC), we need to handle them manually.
The process, since today was manage by admins as mentioned:

1. Deny request
2. Send IM to the inviter asking them to share instead https://slack.bcneng.org.

Managing invites through Slack Events API is not possible without a Business Plan. So we can't do that much.

This PR adds a new feature to candebot that sends an IM to anyone who wants to send an invite to join our Slack workspace as shown:
![image](https://user-images.githubusercontent.com/1083296/114296667-d562b380-9aac-11eb-91ba-dd18d54dd402.png)

With this enhancement, Admins would only need to deny manually **all** requests and forget sending IMs.