### PR TITLE
feat: allow users to report messages

### DIFF
--- a/slackx/slack.go
+++ b/slackx/slack.go
@@ -3,6 +3,7 @@ package slackx
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/slack-go/slack"
 )
@@ -69,4 +70,8 @@ func FindChannelIDByName(client *slack.Client, channel string) (string, error) {
 	}
 
 	return "", fmt.Errorf("channel %s not found", channel)
+}
+
+func LinkToMessage(channelID, msgTimestamp string) string {
+	return fmt.Sprintf("https://bcneng.slack.com/archives/%s/p%s", channelID, strings.Replace(msgTimestamp, ".", "", 1))
 }


### PR DESCRIPTION
This PR adds a new feature to Candebot where Users can now report messages that violate BcnEng's COC, Netiquette or that they consider are not welcomed. 

Any user will now be able to report those by just:

1. Click on "More Actions" button on the right side of the message
![image](https://user-images.githubusercontent.com/1083296/114317170-1982a200-9b07-11eb-8270-5482e47245cc.png)
2. Click on "Report Message"
![](https://user-images.githubusercontent.com/1083296/114317198-3fa84200-9b07-11eb-8bb8-23a5d8d6295c.png).
3. Fill the data and click the "Report" button.
  ![](https://user-images.githubusercontent.com/1083296/114317223-5b134d00-9b07-11eb-918b-627d40aaffa7.png)



This will automatically post a new message on the Staff's channel lookin like the following:
![](https://user-images.githubusercontent.com/1083296/114317268-87c76480-9b07-11eb-9d82-37cbdac94b72.png)


