### PR TITLE
build all PRs, not just those to master

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
 


### PR DESCRIPTION
This opens the option to send a PR to an ongoing PR.

For example, when I'm working on a big feature, I can send a first PR that targets `master`. That first PR is small and it's valuable in itself already so once reviewed it will be mergeable. But! In order to not be blocked, I can continue working on a separate Pr that depends on code I added/changed, so I need to create a new PR that won't target `master` but the branch of the _first_ PR. Therefore, I'd like GH Actions to build all PRs and not only those targeting `master`.
