### PR TITLE
Fix go 1.17 module stuff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,22 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/text v0.3.6
 )
+
+require (
+	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dghubble/go-twitter v0.0.0-20201011215211-4b180d0cc78d // indirect
+	github.com/dghubble/sling v1.3.0 // indirect
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.7.0 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/oauth2 v0.0.0-20210113205817-d3ed898aa8a3 // indirect
+	golang.org/x/sys v0.0.0-20200803210538-64077c9b5642 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+)


### PR DESCRIPTION
Saw some needed `go mod tidy` in another PR. go 1.17 adds some gomod stuff for perf purposes.

Related to https://github.com/bcneng/candebot/pull/60

Error output:
```
Run go build -v .
go: downloading github.com/kelseyhightower/envconfig v1.4.0
go: downloading github.com/alecthomas/kong v0.2.17
go: downloading github.com/bcneng/twitter-contest v0.0.0-20210125112923-eb139f65d81c
go: downloading github.com/slack-go/slack v0.9.4
go: downloading golang.org/x/text v0.3.6
go: downloading github.com/dghubble/go-twitter v0.0.0-20201011215211-4b180d0cc78d
go: downloading github.com/sirupsen/logrus v1.7.0
go: downloading golang.org/x/oauth2 v0.0.0-20210113205817-d3ed898aa8a3
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/gorilla/websocket v1.4.2
go: downloading golang.org/x/sys v0.0.0-20200803210538-64077c9b5642
go: downloading github.com/cenkalti/backoff v2.1.1+incompatible
go: downloading github.com/dghubble/sling v1.3.0
go: downloading github.com/google/go-querystring v1.0.0
go: downloading golang.org/x/net v0.0.0-20200822124328-c89045814202
go: updates to go.mod needed; to update it:
	go mod tidy
Error: Process completed with exit code 1.
```