### PR TITLE
feat: clarify salary expectations

### DIFF
--- a/bot/interact.go
+++ b/bot/interact.go
@@ -175,7 +175,7 @@ func generateSubmitJobFormDialog() slack.Dialog {
 	salaryCurrencyInput.Optional = false
 	salaryCurrencyInput.Hint = "Choose the salary currency from the dropdown"
 
-	salaryMinInput := slack.NewTextInput("min_salary", "Salary min (per year)", "")
+	salaryMinInput := slack.NewTextInput("min_salary", "Salary min (yearly fixed income; no variable/bonus allowed)", "")
 	salaryMinInput.Optional = true
 	salaryMinInput.Placeholder = "60"
 	salaryMinInput.Hint = "Use thousand abbreviation representation. Example: write 60 for 60,000 EUR. Only numbers allowed"
@@ -183,7 +183,7 @@ func generateSubmitJobFormDialog() slack.Dialog {
 	salaryMinInput.MaxLength = 3
 	salaryMinInput.MinLength = 2
 
-	salaryMaxInput := slack.NewTextInput("max_salary", "Salary max (per year)", "")
+	salaryMaxInput := slack.NewTextInput("max_salary", "Salary max (yearly fixed income; no variable/bonus allowed)", "")
 	salaryMaxInput.Placeholder = "90"
 	salaryMaxInput.Hint = "Use thousand abbreviation representation. Example: write 90 for 90,000 EUR. Only numbers allowed"
 	salaryMaxInput.Subtype = slack.InputSubtypeNumber


### PR DESCRIPTION
This comes from the following Slack thread: https://bcneng.slack.com/archives/C30CUFT2B/p1641207091231800

It seems `Salary` field meaning is not clear enough with the expectations. We never considered things like variable income or bonuses to be part of this so now it is more clear (I hope).