### PR TITLE
fix: reduce salary field chars to 48 as it is the max allowed

### DIFF
--- a/bot/interact.go
+++ b/bot/interact.go
@@ -175,7 +175,7 @@ func generateSubmitJobFormDialog() slack.Dialog {
 	salaryCurrencyInput.Optional = false
 	salaryCurrencyInput.Hint = "Choose the salary currency from the dropdown"
 
-	salaryMinInput := slack.NewTextInput("min_salary", "Salary min (yearly fixed income; no variable/bonus allowed)", "")
+	salaryMinInput := slack.NewTextInput("min_salary", "Salary min (yearly fix income;no variable/bonus)", "")
 	salaryMinInput.Optional = true
 	salaryMinInput.Placeholder = "60"
 	salaryMinInput.Hint = "Use thousand abbreviation representation. Example: write 60 for 60,000 EUR. Only numbers allowed"
@@ -183,7 +183,7 @@ func generateSubmitJobFormDialog() slack.Dialog {
 	salaryMinInput.MaxLength = 3
 	salaryMinInput.MinLength = 2
 
-	salaryMaxInput := slack.NewTextInput("max_salary", "Salary max (yearly fixed income; no variable/bonus allowed)", "")
+	salaryMaxInput := slack.NewTextInput("max_salary", "Salary max (yearly fix income;no variable/bonus)", "")
 	salaryMaxInput.Placeholder = "90"
 	salaryMaxInput.Hint = "Use thousand abbreviation representation. Example: write 90 for 90,000 EUR. Only numbers allowed"
 	salaryMaxInput.Subtype = slack.InputSubtypeNumber


### PR DESCRIPTION
Slack API has a field label limitation of 48 chars. 

```
[ERROR] Element 2 field `label` cannot be longer than 48 characters
```