### PR TITLE
Revert "build(deps): bump actions/setup-go from 2 to 3"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v2
       with:
         go-version: ^1.17
       id: go
@@ -33,7 +33,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v2
       with:
         go-version: ^1.17
       id: go


### PR DESCRIPTION
Reverts bcneng/candebot#95

Parece que ser que la v3 sube a go 1.18 y hay algún breaking change de alguna dep.