### PR TITLE
feat: add thread deletion message action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ candebot
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# .env files
+*.env

--- a/bot/interact.go
+++ b/bot/interact.go
@@ -3,7 +3,7 @@ package bot
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/bcneng/candebot/cmd"
 	"github.com/bcneng/candebot/slackx"
 	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
@@ -21,7 +22,7 @@ import (
 
 func interactAPIHandler(botContext cmd.BotContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			log.Printf("Fail to read request body: %v\n", err)
@@ -50,17 +51,32 @@ func interactAPIHandler(botContext cmd.BotContext) http.HandlerFunc {
 				dialog := generateReportMessageDialog()
 				dialog.State = slackx.LinkToMessage(message.Channel.ID, message.MessageTs) // persist the message link across submission
 				if err := botContext.Client.OpenDialog(message.TriggerID, dialog); err != nil {
-					log.Println(err.Error())
+					log.Println(err)
 				}
 			case "delete_job_post":
 				modal := generateDeleteJobPostModal()
 				modal.PrivateMetadata = fmt.Sprintf("%s|%s|%s", message.Channel.ID, message.Message.Text, message.MessageTs) // persist the message channel, text, and ts across submission
 
 				if resp, err := botContext.Client.OpenView(message.TriggerID, modal); err != nil {
-					log.Println(err.Error())
+					log.Println(err)
 					log.Println(strings.Join(resp.ResponseMetadata.Messages, "\n"))
 					log.Println(strings.Join(resp.ResponseMetadata.Warnings, "\n"))
 				}
+			case "delete_thread":
+				if !botContext.IsStaff(message.User.ID) {
+					log.Println("this action is only allowed to Staff members")
+					break
+				}
+
+				modal := generateDeleteThreadModal()
+				modal.PrivateMetadata = fmt.Sprintf("%s|%s", message.Channel.ID, message.MessageTs) // persist the message channel and ts across submission
+
+				if resp, err := botContext.Client.OpenView(message.TriggerID, modal); err != nil {
+					log.Println(err)
+					log.Println(strings.Join(resp.ResponseMetadata.Messages, "\n"))
+					log.Println(strings.Join(resp.ResponseMetadata.Warnings, "\n"))
+				}
+
 			}
 		case slack.InteractionTypeViewSubmission:
 			switch message.View.CallbackID {
@@ -89,8 +105,8 @@ func interactAPIHandler(botContext cmd.BotContext) http.HandlerFunc {
 					return
 				}
 
-				if _, _, err := botContext.Client.DeleteMessage(channelID, messageTS); err != nil {
-					log.Println(err.Error())
+				if _, _, err := botContext.AdminClient.DeleteMessage(channelID, messageTS); err != nil {
+					log.Println(err)
 					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}
@@ -108,6 +124,63 @@ func interactAPIHandler(botContext cmd.BotContext) http.HandlerFunc {
 					Value:     1,
 					Timestamp: time.Now(),
 				})
+			case "delete_thread":
+				// We early set the Content-Type header for any response. This is important.
+				w.Header().Set("Content-Type", "application/json")
+
+				if !botContext.IsStaff(message.User.ID) {
+					_ = json.NewEncoder(w).Encode(
+						slack.NewErrorsViewSubmissionResponse(map[string]string{"input_block": "You are not allowed to delete threads. Please contact any Staff member."}),
+					)
+					return
+				}
+
+				messageData := strings.Split(strings.Trim(message.View.PrivateMetadata, `"`), "|") // For some reason, slack adds an extra double quote
+				channelID := messageData[0]
+				messageTS := messageData[1]
+
+				repliesParams := &slack.GetConversationRepliesParameters{
+					ChannelID: channelID,
+					Timestamp: messageTS,
+				}
+
+				var threadMessages []slack.Message
+				var cursor = ""
+				var more = true
+
+				for more {
+					repliesParams.Cursor = cursor
+					var replies []slack.Message
+					replies, more, cursor, err = botContext.Client.GetConversationReplies(repliesParams)
+					if err != nil {
+						_ = json.NewEncoder(w).Encode(slack.NewErrorsViewSubmissionResponse(map[string]string{"input_block": err.Error()}))
+						return
+					}
+
+					threadMessages = append(threadMessages, replies...)
+				}
+
+				go func() {
+					ok := deleteThreadMessages(botContext, threadMessages, channelID, messageTS)
+					if !ok {
+						log.Println("Thread deletion finished with errors (see logs)", message.View.PrivateMetadata)
+					} else {
+						log.Println("Thread deletion finished successfully", message.View.PrivateMetadata)
+					}
+
+					//Sending metrics
+					botContext.Harvester.RecordMetric(telemetry.Count{
+						Name: "candebot.thread.deleted",
+						Attributes: map[string]interface{}{
+							"candebot_version": botContext.Version,
+							"errored":          !ok,
+						},
+						Value:     1,
+						Timestamp: time.Now(),
+					})
+				}()
+
+				_ = json.NewEncoder(w).Encode(slack.NewClearViewSubmissionResponse())
 			}
 
 		case slack.InteractionTypeDialogSubmission:
@@ -195,20 +268,60 @@ func interactAPIHandler(botContext cmd.BotContext) http.HandlerFunc {
 			switch message.CallbackID {
 			case "submit_job":
 				if err := botContext.Client.OpenDialog(message.TriggerID, generateSubmitJobFormDialog()); err != nil {
-					log.Println(err.Error())
+					log.Println(err)
 				}
 			}
 		}
 	}
 }
 
+func deleteThreadMessages(botContext cmd.BotContext, threadMessages []slack.Message, channelID, parentMessageTS string) bool {
+	var errored bool
+	for _, threadMessage := range threadMessages {
+		if threadMessage.Timestamp == parentMessageTS {
+			// Do not delete the parent message
+			continue
+		}
+
+		deleteMessageErr := retry.Do(
+			func() error {
+				_, _, err := botContext.AdminClient.DeleteMessage(channelID, threadMessage.Timestamp)
+				if err != nil {
+					switch actualErr := err.(type) {
+					case *slack.RateLimitedError:
+						log.Printf("Rate limit reached (Slack Web API Rate Limit: Tier 3. 50+ per minute). Waiting %s for making next request...", actualErr.RetryAfter)
+						time.Sleep(actualErr.RetryAfter)
+
+						return err
+					}
+
+					return retry.Unrecoverable(err) // Only retry if rate limited
+				}
+
+				return nil
+			},
+			retry.Attempts(0), // unlimited unless the error is not rate limit reached
+			retry.OnRetry(func(n uint, err error) {
+				log.Printf("Retrying thread message %s deletion because of err: %s", threadMessage.Timestamp, err)
+			}),
+		)
+
+		if deleteMessageErr != nil {
+			errored = true
+			log.Printf("Thread message %s deletion errored: %s", threadMessage.Timestamp, deleteMessageErr)
+		}
+
+	}
+	return !errored
+}
+
 // validateSubmission runs validations over the submitted salary range and job offer link. Produces a list of errors if any.
 //
 // Arguments are the strings as read from the submissions (no previous transform/parsing/filter)
 // Returns:
-//  - the parsed max salary as int
-//  - the parsed min salary as int, or -1 if the field was empty (it's an optional field)
-//  - a map of field name to error message
+//   - the parsed max salary as int
+//   - the parsed min salary as int, or -1 if the field was empty (it's an optional field)
+//   - a map of field name to error message
 func validateSubmission(messageJobLink, messageMaxSalary, messageMinSalary string) (int, int, map[string]string) {
 
 	validationErrors := make(map[string]string)
@@ -342,6 +455,25 @@ func generateDeleteJobPostModal() slack.ModalViewRequest {
 		}},
 		Submit:     slack.NewTextBlockObject(slack.PlainTextType, "Confirm", false, false),
 		CallbackID: "delete_job_post",
+	}
+}
+
+func generateDeleteThreadModal() slack.ModalViewRequest {
+	checkBoxOptionText := slack.NewTextBlockObject("plain_text", "I am sure I want to delete the thread", false, false)
+	checkBoxDescriptionText := slack.NewTextBlockObject("plain_text", "By selecting this, you confirm you understand that whole thread is going to be deleted permanently", false, false)
+	checkbox := slack.NewCheckboxGroupsBlockElement("some_action", slack.NewOptionBlockObject("confirmed", checkBoxOptionText, checkBoxDescriptionText))
+	block := slack.NewInputBlock("input_block", slack.NewTextBlockObject(slack.PlainTextType, " ", false, false), checkbox)
+	noticeBlock := slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, "Note that this could take some time due to <https://api.slack.com/docs/rate-limits|Slack Web API Rate Limit limitations: Tier 3. (50+ per minute)>. The execution will take place in a background process.", false, false), nil, nil)
+
+	return slack.ModalViewRequest{
+		Type:  slack.VTModal,
+		Title: slack.NewTextBlockObject(slack.PlainTextType, "Confirm deletion", false, false),
+		Blocks: slack.Blocks{BlockSet: []slack.Block{
+			block,
+			noticeBlock,
+		}},
+		Submit:     slack.NewTextBlockObject(slack.PlainTextType, "Confirm", false, false),
+		CallbackID: "delete_thread",
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/avast/retry-go/v4 v4.3.1 // indirect
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dghubble/go-twitter v0.0.0-20201011215211-4b180d0cc78d // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/alecthomas/kong v0.7.1 h1:azoTh0IOfwlAX3qN9sHWTxACE2oV8Bg2gAwBsMwDQY4
 github.com/alecthomas/kong v0.7.1/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=
 github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
 github.com/alecthomas/repr v0.1.0/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
+github.com/avast/retry-go/v4 v4.3.1 h1:Mtg11F9PdAIMkMiio2RKcYauoVHjl2aB3zQJJlzD4cE=
+github.com/avast/retry-go/v4 v4.3.1/go.mod h1:rg6XFaiuFYII0Xu3RDbZQkxCofFwruZKW8oEF1jpWiU=
 github.com/aws/aws-lambda-go v1.22.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
 github.com/bcneng/twitter-contest v0.0.0-20210125112923-eb139f65d81c h1:5z6NcH61W9u56c9jPwhMVzrRuwEsOSmYuOF2Pbl/WdI=
 github.com/bcneng/twitter-contest v0.0.0-20210125112923-eb139f65d81c/go.mod h1:aj3KvUR4H9ZeNh/wkubEK6WPCA9KEtb/g0Q7znOqaWE=


### PR DESCRIPTION
This PR adds a new message action that allows **only staff members** to delete **all** messages from a given thread.

<img width="671" alt="2022-11-28 at 23 40 17@2x" src="https://user-images.githubusercontent.com/1083296/204403612-6f06b930-78b9-4e4c-b832-2fcd1cf30783.png">

<img width="518" alt="2022-11-28 at 23 40 32@2x" src="https://user-images.githubusercontent.com/1083296/204403629-18d38ed3-99ed-4640-a9e5-fe734964848e.png">

