### PR TITLE
feat: add utm_source to job offer links

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,40 +1,30 @@
 name: Go
-
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v4
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-
-    - name: Build
-      run: make build
-
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
     - name: Test
       run: make build test
-
+    - name: Build
+      run: make build
   check-lint:
     name: Lint checks
     runs-on: ubuntu-latest
     steps:
-
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v4
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.57.2
 

--- a/bot/interact_test.go
+++ b/bot/interact_test.go
@@ -18,60 +18,63 @@ func requireHasError(t *testing.T, errorMessage string) {
 func TestJobSubmission(t *testing.T) {
 
 	t.Run("fields for the salary are properly parsed", func(t *testing.T) {
-		max, min, _ := validateSubmission("http://foo.com", "12", "10")
+		link, max, min, _ := validateSubmission("http://foo.com", "12", "10")
+		require.NotNil(t, link)
 		require.Equal(t, 12, max)
 		require.Equal(t, 10, min)
 	})
 
 	t.Run("the job link must be a valid URI", func(t *testing.T) {
-		_, _, validaterrors := validateSubmission("http://foo.com", "12", "10")
+		link, _, _, validaterrors := validateSubmission("http://foo.com", "12", "10")
 		require.Empty(t, validaterrors["job_link"])
+		require.NotNil(t, link)
 	})
 
 	t.Run("min salary is optional (and function returns -1 when left blank)", func(t *testing.T) {
-		_, minSalary, _ := validateSubmission("hamburger", "12", "")
+		_, _, minSalary, _ := validateSubmission("http://foo.com", "12", "")
 		require.Equal(t, -1, minSalary)
 	})
 
 	// FIXME: The following tests may be rewritten as a table-driven test
 	// https://github.com/bcneng/candebot/pull/72#pullrequestreview-773870224
 	t.Run("must reject non-URI links", func(t *testing.T) {
-		_, _, validaterrors := validateSubmission("hamburger", "12", "10")
+		link, _, _, validaterrors := validateSubmission("hamburger", "12", "10")
 		requireHasError(t, validaterrors["job_link"])
+		require.Nil(t, link)
 	})
 
 	t.Run("must include a max salary", func(t *testing.T) {
-		_, _, validaterrors := validateSubmission("hamburger", "", "10")
+		_, _, _, validaterrors := validateSubmission("http://foo.com", "", "10")
 		requireHasError(t, validaterrors["max_salary"])
 	})
 
 	t.Run("max salary must be a positive number", func(t *testing.T) {
-		_, _, validaterrors := validateSubmission("hamburger", "-1", "10")
+		_, _, _, validaterrors := validateSubmission("http://foo.com", "-1", "10")
 		requireHasError(t, validaterrors["max_salary"])
 	})
 
 	t.Run("max salary must be a number", func(t *testing.T) {
-		_, _, validaterrors := validateSubmission("hamburger", "-asdf", "10")
+		_, _, _, validaterrors := validateSubmission("http://foo.com", "-asdf", "10")
 		requireHasError(t, validaterrors["max_salary"])
 	})
 
 	t.Run("min salary must be a number", func(t *testing.T) {
-		_, _, validaterrors := validateSubmission("hamburger", "12", "asdf")
+		_, _, _, validaterrors := validateSubmission("http://foo.com", "12", "asdf")
 		requireHasError(t, validaterrors["min_salary"])
 	})
 
 	t.Run("min salary must be a positive number", func(t *testing.T) {
-		_, _, validaterrors := validateSubmission("hamburger", "12", "-5")
+		_, _, _, validaterrors := validateSubmission("http://foo.com", "12", "-5")
 		requireHasError(t, validaterrors["min_salary"])
 	})
 
 	t.Run("max salary must be greater than the min salary", func(t *testing.T) {
-		_, _, validaterrors := validateSubmission("hamburger", "8", "10")
+		_, _, _, validaterrors := validateSubmission("http://foo.com", "8", "10")
 		requireHasError(t, validaterrors["min_salary"])
 	})
 
 	t.Run("max salary must not be greater than 2.5x the min salary", func(t *testing.T) {
-		_, _, validaterrors := validateSubmission("hamburger", "13", "5")
+		_, _, _, validaterrors := validateSubmission("http://foo.com", "13", "5")
 		requireHasError(t, validaterrors["max_salary"])
 	})
 


### PR DESCRIPTION
This PR adds `utm_source` query param to job offers with the value `bcneng`. In case there is a `utm_source` in place, it won't modify it.

This is helpful, a bit, to keep track of our links in external systems.

Additionally, this PR upgrades the GH workflow for CI.