### PR TITLE
feat: embed git commit hash as version in builds

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: actions/setup-go@v5
     - name: Test
       run: make build test

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean:
 	rm -f candebot 
 
 build: clean
-	go build -v .
+	go build -v -ldflags "-X main.Version=$$(git rev-parse --short HEAD)" .
 	@echo candebot built and ready to serve and protect.
 
 test:


### PR DESCRIPTION
## Summary
- Add `-ldflags` to Makefile to embed git commit hash as version
- Update GitHub workflow to fetch full git history for version extraction

Fixes version command showing "unknown" by injecting git commit hash during build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)