### PR TITLE
Use a website repo json with channel IDs as a channel id data source

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -42,9 +42,12 @@ func WakeUp(_ context.Context, conf Config, bus EventBus.Bus) error {
 		log.Println("[WARN] No metrics will be sent to NR as there is no License Key configured")
 	}
 
+	channelResolver := slackx.NewChannelResolver(http.DefaultClient, client)
+	cliContext.ChannelResolver = channelResolver
+
 	if len(conf.RateLimits) > 0 {
 		rateLimiter, err := NewRateLimiter(conf.RateLimits, func(name string) (string, error) {
-			return slackx.FindChannelIDByName(client, name)
+			return channelResolver.FindChannelIDByName(name)
 		})
 		if err != nil {
 			return err

--- a/bot/context.go
+++ b/bot/context.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/asaskevich/EventBus"
+	"github.com/bcneng/candebot/slackx"
 	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
 	"github.com/slack-go/slack"
 )
@@ -17,6 +18,7 @@ type Context struct {
 	TwitterContestToken string
 	Harvester           *telemetry.Harvester
 	RateLimiter         *RateLimiter
+	ChannelResolver     *slackx.ChannelResolver
 
 	Bus EventBus.Bus
 

--- a/cmd/echo.go
+++ b/cmd/echo.go
@@ -32,7 +32,7 @@ func (e *Echo) Run(ctx bot.Context, slackCtx bot.SlackContext) error {
 		channel = channel[0:i]
 	}
 
-	channelID, err := slackx.FindChannelIDByName(ctx.Client, channel)
+	channelID, err := ctx.ChannelResolver.FindChannelIDByName(channel)
 	if err != nil {
 		_ = slackx.SendEphemeral(ctx.Client, slackCtx.ThreadTimestamp, slackCtx.Channel, slackCtx.User, fmt.Sprintf("Error during channel lookup. Error: %s", err.Error()))
 		return err

--- a/slackx/slack.go
+++ b/slackx/slack.go
@@ -1,14 +1,35 @@
 package slackx
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/slack-go/slack"
 )
 
-var channelNameToIDCache map[string]string
+// ChannelResolver resolves channel names to IDs using channels.json and Slack API fallback.
+type ChannelResolver struct {
+	httpClient  *http.Client
+	slackClient *slack.Client
+	jsonURL     string
+	cache       map[string]string
+	mu          sync.RWMutex
+}
+
+// NewChannelResolver creates a new channel resolver.
+func NewChannelResolver(httpClient *http.Client, slackClient *slack.Client) *ChannelResolver {
+	return &ChannelResolver{
+		httpClient:  httpClient,
+		slackClient: slackClient,
+		jsonURL:     "https://raw.githubusercontent.com/bcneng/website/refs/heads/main/data/channels.json",
+		cache:       make(map[string]string),
+	}
+}
 
 func SendEphemeral(c *slack.Client, threadTS, channelID, userID, msg string, opts ...slack.MsgOption) error {
 	if userID == "" || channelID == "" {
@@ -37,36 +58,92 @@ func Send(c *slack.Client, threadTS, channelID, msg string, scape bool, opts ...
 
 var publicPrivate = []string{"public_channel", "private_channel"}
 
-func FindChannelIDByName(client *slack.Client, channel string) (string, error) {
-	if channelNameToIDCache == nil {
-		channelNameToIDCache = make(map[string]string)
-	}
+type channelData struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+}
 
-	id, ok := channelNameToIDCache[channel]
+// FindChannelIDByName resolves a channel name to its ID.
+// It first checks the cache, then channels.json, and finally falls back to the Slack API.
+func (r *ChannelResolver) FindChannelIDByName(channel string) (string, error) {
+	// Check cache with read lock
+	r.mu.RLock()
+	id, ok := r.cache[channel]
+	r.mu.RUnlock()
 	if ok {
 		return id, nil
 	}
 
+	// Try fetching from channels.json first to avoid Slack API rate limits
+	if id, found := r.findInChannelsJSON(channel); found {
+		return id, nil
+	}
+
+	// Fallback to Slack API if not found in channels.json
+	return r.findViaSlackAPI(channel)
+}
+
+func (r *ChannelResolver) findInChannelsJSON(channel string) (string, bool) {
+	resp, err := r.httpClient.Get(r.jsonURL)
+	if err != nil {
+		return "", false
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", false
+	}
+
+	var channelsData []channelData
+	if err := json.Unmarshal(body, &channelsData); err != nil {
+		return "", false
+	}
+
+	for _, ch := range channelsData {
+		if ch.Name != channel {
+			continue
+		}
+
+		r.mu.Lock()
+		r.cache[channel] = ch.ID
+		r.mu.Unlock()
+		return ch.ID, true
+	}
+
+	return "", false
+}
+
+func (r *ChannelResolver) findViaSlackAPI(channel string) (string, error) {
 	var cursor string
-	var channels []slack.Channel
 	for {
-		var err error
-		channels, cursor, err = client.GetConversations(&slack.GetConversationsParameters{Cursor: cursor, ExcludeArchived: true, Types: publicPrivate})
+		channels, nextCursor, err := r.slackClient.GetConversations(&slack.GetConversationsParameters{
+			Cursor:          cursor,
+			ExcludeArchived: true,
+			Types:           publicPrivate,
+		})
 		if err != nil {
 			return "", err
 		}
 
-		if cursor == "" {
+		for _, ch := range channels {
+			if ch.Name != channel {
+				continue
+			}
+
+			r.mu.Lock()
+			r.cache[channel] = ch.ID
+			r.mu.Unlock()
+			return ch.ID, nil
+		}
+
+		if nextCursor == "" {
 			break
 		}
-	}
-
-	for _, c := range channels {
-		if c.Name == channel {
-			channelNameToIDCache[channel] = c.ID // It is fine to not lock.
-
-			return c.ID, nil
-		}
+		cursor = nextCursor
 	}
 
 	return "", fmt.Errorf("channel %s not found", channel)

--- a/slackx/slack_test.go
+++ b/slackx/slack_test.go
@@ -1,0 +1,101 @@
+package slackx
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindChannelIDByName_FromChannelsJSON(t *testing.T) {
+	channelsJSON := `[
+		{"name": "general", "id": "C123456"},
+		{"name": "candebot-testing", "id": "C789012"},
+		{"name": "random", "id": "C345678"}
+	]`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(channelsJSON))
+	}))
+	defer server.Close()
+
+	resolver := NewChannelResolver(server.Client(), slack.New("test-token"))
+	resolver.jsonURL = server.URL
+
+	id, err := resolver.FindChannelIDByName("candebot-testing")
+	require.NoError(t, err)
+	require.Equal(t, "C789012", id)
+
+	// Verify it's cached
+	resolver.mu.RLock()
+	cachedID, ok := resolver.cache["candebot-testing"]
+	resolver.mu.RUnlock()
+	require.True(t, ok, "expected channel to be cached")
+	require.Equal(t, "C789012", cachedID)
+}
+
+func TestFindChannelIDByName_CacheHit(t *testing.T) {
+	resolver := NewChannelResolver(&http.Client{}, slack.New("test-token"))
+
+	// Pre-populate cache
+	resolver.cache["cached-channel"] = "C999999"
+
+	id, err := resolver.FindChannelIDByName("cached-channel")
+	require.NoError(t, err)
+	require.Equal(t, "C999999", id)
+}
+
+func TestFindChannelIDByName_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	resolver := NewChannelResolver(server.Client(), slack.New("test-token"))
+	resolver.jsonURL = server.URL
+
+	// Should fallback to Slack API (which will fail in this test, but that's expected)
+	_, err := resolver.FindChannelIDByName("test-channel")
+	require.Error(t, err, "expected error from Slack API fallback")
+}
+
+func TestFindChannelIDByName_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`invalid json`))
+	}))
+	defer server.Close()
+
+	resolver := NewChannelResolver(server.Client(), slack.New("test-token"))
+	resolver.jsonURL = server.URL
+
+	// Should fallback to Slack API (which will fail in this test, but that's expected)
+	_, err := resolver.FindChannelIDByName("test-channel")
+	require.Error(t, err, "expected error from Slack API fallback")
+}
+
+func TestFindChannelIDByName_ChannelNotInJSON(t *testing.T) {
+	channelsJSON := `[
+		{"name": "general", "id": "C123456"},
+		{"name": "random", "id": "C345678"}
+	]`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(channelsJSON))
+	}))
+	defer server.Close()
+
+	resolver := NewChannelResolver(server.Client(), slack.New("test-token"))
+	resolver.jsonURL = server.URL
+
+	// Should fallback to Slack API (which will fail in this test, but that's expected)
+	_, err := resolver.FindChannelIDByName("missing-channel")
+	require.Error(t, err, "expected error from Slack API fallback")
+}


### PR DESCRIPTION
try fixing:

```
Nov 04 11:35:33  2025/11/04 11:35:33 get channel ID for "candebot-testing": slack rate limit exceeded, retry after 30s
Nov 04 11:35:32  ERROR failed health checks after 8 attempts with error Readiness probe failed: dial tcp 10.244.41.192:8080: connect: connection refused
Nov 04 11:35:33  ERROR component terminated with non-zero exit code: 1,
```