### PR TITLE
Add channel weekly suggester (#240)

### DIFF
--- a/.bot.toml
+++ b/.bot.toml
@@ -26,6 +26,11 @@ general = "C2Y6L58TX" # general
 [twitter]
 contestURL = "https://bcneng-twitter-contest.netlify.app/.netlify/functions/contest"
 
+# Channel weekly suggester configuration
+# Posts random channel suggestions to #general every week
+[channel_suggester]
+num_channels = 3
+
 # Rate limiting configuration
 # Limits how many non-thread messages a user can post in specific channels
 # Staff members are exempt from rate limits

--- a/bot/config.go
+++ b/bot/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	Twitter             ConfigTwitter             `env:",prefix=TWITTER_"`
 	RateLimits          []RateLimitConfig         `toml:"rate_limits"`
 	TrackingDetection   []TrackingDetectionConfig `toml:"tracking_detection"`
+	ChannelSuggester    ChannelSuggesterConfig    `toml:"channel_suggester" env:",prefix=CHANNEL_SUGGESTER_"`
 	TwitterContestToken string                    `env:"TWITTER_CONTEST_TOKEN"`
 	TwitterContestURL   string                    `env:"TWITTER_CONTEST_URL"`
 	NewRelicLicenseKey  string                    `env:"NEW_RELIC_LICENSE_KEY"`
@@ -112,4 +113,8 @@ type RateLimitConfig struct {
 
 type TrackingDetectionConfig struct {
 	ChannelName string `toml:"channel_name"`
+}
+
+type ChannelSuggesterConfig struct {
+	NumChannels int `toml:"num_channels" env:"NUM_CHANNELS,default=3"`
 }

--- a/bot/context.go
+++ b/bot/context.go
@@ -22,7 +22,7 @@ type Context struct {
 	RateLimiter         *RateLimiter
 	ChannelResolver     *slackx.ChannelResolver
 	TrackingDetector    *privacy.TrackingDetector
-	ChannelSuggester   *suggest.ChannelSuggester
+	ChannelSuggester    *suggest.ChannelSuggester
 
 	Bus EventBus.Bus
 

--- a/bot/context.go
+++ b/bot/context.go
@@ -6,6 +6,7 @@ import (
 	"github.com/asaskevich/EventBus"
 	"github.com/bcneng/candebot/internal/privacy"
 	"github.com/bcneng/candebot/slackx"
+	"github.com/bcneng/candebot/suggest"
 	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
 	"github.com/slack-go/slack"
 )
@@ -21,6 +22,7 @@ type Context struct {
 	RateLimiter         *RateLimiter
 	ChannelResolver     *slackx.ChannelResolver
 	TrackingDetector    *privacy.TrackingDetector
+	ChannelSuggester   *suggest.ChannelSuggester
 
 	Bus EventBus.Bus
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -15,6 +15,7 @@ type CLI struct {
 	Candebirthday CandeBirthday `cmd:"" help:"Days until @sdecandelario birthday!"`
 	Echo          Echo          `cmd:"" help:"Sends a message from the bot user" placeholder:"echo #general Hi folks!"`
 	Contest       Contest       `cmd:"" help:"Runs a contest on Twitter"`
+	Suggest       Suggest       `cmd:"" help:"Suggests random channels to discover"`
 	Help          Help          `cmd:""`
 }
 

--- a/cmd/suggest.go
+++ b/cmd/suggest.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/bcneng/candebot/bot"
+	"github.com/bcneng/candebot/slackx"
+	"github.com/bcneng/candebot/suggest"
+)
+
+type Suggest struct{}
+
+func (c *Suggest) Run(ctx bot.Context, slackCtx bot.SlackContext) error {
+	if !ctx.IsStaff(slackCtx.User) {
+		return errors.New("this action is only allowed to Staff members")
+	}
+
+	if ctx.ChannelSuggester == nil {
+		return errors.New("channel suggester is not configured")
+	}
+
+	channels, err := ctx.ChannelSuggester.FetchChannels()
+	if err != nil {
+		return err
+	}
+
+	suggestable := suggest.FilterSuggestable(channels)
+	selected := suggest.SelectRandom(suggestable, ctx.Config.ChannelSuggester.NumChannels)
+	if len(selected) == 0 {
+		return errors.New("no suggestable channels found")
+	}
+
+	msg := suggest.FormatMessage(selected)
+	return slackx.Send(ctx.Client, slackCtx.ThreadTimestamp, slackCtx.Channel, msg, false)
+}

--- a/suggest/suggest.go
+++ b/suggest/suggest.go
@@ -1,0 +1,173 @@
+package suggest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/bcneng/candebot/slackx"
+	"github.com/slack-go/slack"
+)
+
+const channelsJSONURL = "https://raw.githubusercontent.com/bcneng/website/refs/heads/main/data/channels.json"
+
+// Channel represents a community Slack channel from channels.json.
+type Channel struct {
+	Name        string   `json:"name"`
+	ID          string   `json:"id"`
+	Description string   `json:"description"`
+	Notes       string   `json:"notes"`
+	Category    string   `json:"category"`
+	Tags        []string `json:"tags"`
+}
+
+// ChannelSuggester fetches channels from the BcnEng website and posts
+// weekly suggestions to a target channel.
+type ChannelSuggester struct {
+	httpClient  *http.Client
+	slackClient *slack.Client
+	channelsURL string
+}
+
+// NewChannelSuggester creates a new ChannelSuggester.
+func NewChannelSuggester(httpClient *http.Client, slackClient *slack.Client) *ChannelSuggester {
+	return &ChannelSuggester{
+		httpClient:  httpClient,
+		slackClient: slackClient,
+		channelsURL: channelsJSONURL,
+	}
+}
+
+// FetchChannels fetches the full list of channels from channels.json.
+func (s *ChannelSuggester) FetchChannels() ([]Channel, error) {
+	resp, err := s.httpClient.Get(s.channelsURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching channels.json: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching channels.json: unexpected status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading channels.json body: %w", err)
+	}
+
+	var channels []Channel
+	if err := json.Unmarshal(body, &channels); err != nil {
+		return nil, fmt.Errorf("parsing channels.json: %w", err)
+	}
+
+	return channels, nil
+}
+
+// FilterSuggestable filters out channels that should not be suggested,
+// such as core channels that everyone already knows about.
+func FilterSuggestable(channels []Channel) []Channel {
+	var result []Channel
+	for _, ch := range channels {
+		if ch.Category == "core" {
+			continue
+		}
+		if hasTag(ch.Tags, "default") {
+			continue
+		}
+		result = append(result, ch)
+	}
+	return result
+}
+
+// SelectRandom picks n random channels from the given list.
+// If n >= len(channels), all channels are returned (shuffled).
+func SelectRandom(channels []Channel, n int) []Channel {
+	if len(channels) == 0 {
+		return nil
+	}
+
+	shuffled := make([]Channel, len(channels))
+	copy(shuffled, channels)
+	rand.Shuffle(len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+
+	if n >= len(shuffled) {
+		return shuffled
+	}
+	return shuffled[:n]
+}
+
+// FormatMessage creates a Slack message with channel suggestions.
+func FormatMessage(channels []Channel) string {
+	if len(channels) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString(":wave: *Weekly Channel Suggestions*\n\n")
+	sb.WriteString("Here are some channels you might want to check out:\n\n")
+
+	for _, ch := range channels {
+		sb.WriteString(fmt.Sprintf("• <#%s> — %s\n", ch.ID, ch.Description))
+	}
+
+	sb.WriteString("\nJoin the conversation! :speech_balloon:")
+	return sb.String()
+}
+
+// PostSuggestion fetches channels, picks random ones, and posts the suggestion
+// to the specified target channel.
+func (s *ChannelSuggester) PostSuggestion(targetChannelID string, numChannels int) error {
+	channels, err := s.FetchChannels()
+	if err != nil {
+		return err
+	}
+
+	suggestable := FilterSuggestable(channels)
+	selected := SelectRandom(suggestable, numChannels)
+	if len(selected) == 0 {
+		return fmt.Errorf("no suggestable channels found")
+	}
+
+	msg := FormatMessage(selected)
+	return slackx.Send(s.slackClient, "", targetChannelID, msg, false)
+}
+
+// StartWeekly starts a goroutine that posts channel suggestions weekly.
+// It blocks until the context is cancelled.
+func (s *ChannelSuggester) StartWeekly(ctx context.Context, targetChannelID string, numChannels int) {
+	ticker := time.NewTicker(7 * 24 * time.Hour)
+	defer ticker.Stop()
+
+	log.Printf("[INFO] Channel suggester started, will post to %s every 7 days", targetChannelID)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("[INFO] Channel suggester stopped")
+			return
+		case <-ticker.C:
+			if err := s.PostSuggestion(targetChannelID, numChannels); err != nil {
+				log.Printf("[ERROR] Channel suggester failed to post: %v", err)
+			} else {
+				log.Println("[INFO] Channel suggester posted weekly suggestion")
+			}
+		}
+	}
+}
+
+func hasTag(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}

--- a/suggest/suggest.go
+++ b/suggest/suggest.go
@@ -72,7 +72,7 @@ func (s *ChannelSuggester) FetchChannels() ([]Channel, error) {
 // FilterSuggestable filters out channels that should not be suggested,
 // such as core channels that everyone already knows about.
 func FilterSuggestable(channels []Channel) []Channel {
-	var result []Channel
+	result := make([]Channel, 0, len(channels))
 	for _, ch := range channels {
 		if ch.Category == "core" {
 			continue

--- a/suggest/suggest_test.go
+++ b/suggest/suggest_test.go
@@ -1,0 +1,115 @@
+package suggest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterSuggestable(t *testing.T) {
+	channels := []Channel{
+		{Name: "general", ID: "C1", Category: "core", Tags: []string{"default", "read-only"}},
+		{Name: "offtopic-random", ID: "C2", Category: "core", Tags: []string{"default"}},
+		{Name: "golang", ID: "C3", Category: "languages", Tags: []string{}},
+		{Name: "python", ID: "C4", Category: "languages", Tags: []string{}},
+		{Name: "welcome", ID: "C5", Category: "core", Tags: []string{"default"}},
+		{Name: "devops", ID: "C6", Category: "systems", Tags: []string{}},
+	}
+
+	result := FilterSuggestable(channels)
+
+	assert.Len(t, result, 3)
+	names := make([]string, len(result))
+	for i, ch := range result {
+		names[i] = ch.Name
+	}
+	assert.Contains(t, names, "golang")
+	assert.Contains(t, names, "python")
+	assert.Contains(t, names, "devops")
+}
+
+func TestFilterSuggestable_ExcludesDefaultTag(t *testing.T) {
+	channels := []Channel{
+		{Name: "hiring-job-board", ID: "C1", Category: "hr", Tags: []string{"default"}},
+		{Name: "rust", ID: "C2", Category: "languages", Tags: []string{}},
+	}
+
+	result := FilterSuggestable(channels)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "rust", result[0].Name)
+}
+
+func TestFilterSuggestable_EmptyInput(t *testing.T) {
+	result := FilterSuggestable(nil)
+	assert.Nil(t, result)
+}
+
+func TestSelectRandom(t *testing.T) {
+	channels := []Channel{
+		{Name: "golang", ID: "C1"},
+		{Name: "python", ID: "C2"},
+		{Name: "rust", ID: "C3"},
+		{Name: "devops", ID: "C4"},
+		{Name: "testing", ID: "C5"},
+	}
+
+	result := SelectRandom(channels, 3)
+
+	require.Len(t, result, 3)
+	// Verify all selected channels come from the original list
+	nameSet := map[string]bool{"golang": true, "python": true, "rust": true, "devops": true, "testing": true}
+	for _, ch := range result {
+		assert.True(t, nameSet[ch.Name], "unexpected channel: %s", ch.Name)
+	}
+	// Verify no duplicates
+	seen := map[string]bool{}
+	for _, ch := range result {
+		assert.False(t, seen[ch.Name], "duplicate channel: %s", ch.Name)
+		seen[ch.Name] = true
+	}
+}
+
+func TestSelectRandom_MoreThanAvailable(t *testing.T) {
+	channels := []Channel{
+		{Name: "golang", ID: "C1"},
+		{Name: "python", ID: "C2"},
+	}
+
+	result := SelectRandom(channels, 5)
+
+	assert.Len(t, result, 2)
+}
+
+func TestSelectRandom_EmptyInput(t *testing.T) {
+	result := SelectRandom(nil, 3)
+	assert.Nil(t, result)
+}
+
+func TestFormatMessage(t *testing.T) {
+	channels := []Channel{
+		{Name: "golang", ID: "C1", Description: "All things Go"},
+		{Name: "python", ID: "C2", Description: "Python programming"},
+	}
+
+	msg := FormatMessage(channels)
+
+	assert.Contains(t, msg, "Weekly Channel Suggestions")
+	assert.Contains(t, msg, "<#C1>")
+	assert.Contains(t, msg, "<#C2>")
+	assert.Contains(t, msg, "All things Go")
+	assert.Contains(t, msg, "Python programming")
+}
+
+func TestFormatMessage_EmptyInput(t *testing.T) {
+	msg := FormatMessage(nil)
+	assert.Empty(t, msg)
+}
+
+func TestHasTag(t *testing.T) {
+	assert.True(t, hasTag([]string{"default", "read-only"}, "default"))
+	assert.True(t, hasTag([]string{"default", "read-only"}, "read-only"))
+	assert.False(t, hasTag([]string{"default", "read-only"}, "anonymous-enabled"))
+	assert.False(t, hasTag(nil, "default"))
+}

--- a/suggest/suggest_test.go
+++ b/suggest/suggest_test.go
@@ -43,7 +43,7 @@ func TestFilterSuggestable_ExcludesDefaultTag(t *testing.T) {
 
 func TestFilterSuggestable_EmptyInput(t *testing.T) {
 	result := FilterSuggestable(nil)
-	assert.Nil(t, result)
+	assert.Empty(t, result)
 }
 
 func TestSelectRandom(t *testing.T) {


### PR DESCRIPTION
Add a weekly channel suggestion feature that promotes community channels
in #general. Fetches channel data from bcneng/website channels.json,
filters out core/default channels, and posts random suggestions weekly.

Includes a staff-only `suggest` command for manual triggering.

https://claude.ai/code/session_018mnu9Q4jeT6FRcBKZfcxsJ