### PR TITLE
ci: run the lint config the repo actually declares

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,30 +3,34 @@ on:
   push:
     branches: [ main ]
   pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-go@v5
-    - name: Test
-      run: make build test
-    - name: Build
-      run: make build
-  check-lint:
-    name: Lint checks
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
-          cache: false
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+          go-version: stable
+      - name: Build
+        run: make build
+      - name: Test
+        run: make test
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          version: v1.57.2
-
+          go-version: stable
+      - name: Lint
+        run: make lint


### PR DESCRIPTION
CI's lint gate has not been enforcing `.golangci.yml`. The config is schema v2, but the workflow pinned golangci-lint v1.57.2, which does not recognise the v2-only `linters.settings` and `formatters` sections and drops them without erroring. The revive rule list and the goimports check have been dead in CI, so the green checks came from a weaker default set. Probing both binaries against the same config: v2.6.0 flags `get-return` and goimports violations, v1.57.2 flags neither.

Lint now runs `make lint`, so CI and local share the single version pinned in the Makefile and cannot drift apart again. The tradeoff is compiling golangci-lint on a cold cache instead of downloading a prebuilt binary.

Also renames the build job to test and drops the duplicate `make build`, which ran clean+build twice while `make test` does not need the binary. Both jobs now pin `go-version: stable`, replacing the spread of go.mod 1.20, the lint job's 1.21 and the build job's unpinned runner default. Adds least-privilege permissions and cancellation of superseded pull request runs.